### PR TITLE
Diffusion examples

### DIFF
--- a/examples/diffusion/CMakeLists.txt
+++ b/examples/diffusion/CMakeLists.txt
@@ -2,5 +2,6 @@ project(diffusion LANGUAGES CXX)
 
 add_executable(${PROJECT_NAME} "${PROJECT_NAME}.cpp")
 target_link_libraries(${PROJECT_NAME} PRIVATE ViennaCS)
+configure_file(config.txt ${CMAKE_CURRENT_BINARY_DIR}/config.txt COPYONLY)
 
 add_dependencies(ViennaCS_Examples ${PROJECT_NAME})

--- a/examples/diffusion/config.txt
+++ b/examples/diffusion/config.txt
@@ -1,0 +1,20 @@
+# Domain
+gridDelta = 1.5  # nm
+xExtent = 80     # nm
+yExtent = 80     # nm
+
+# Geometry
+substrateHeight = 50  # nm
+coverHeight = 30
+maskHeight = 10
+holeRadius = 13.3
+
+# Process
+duration = 20               # s
+diffusionCoefficient = 1    # nm²/s
+velocity = 0                # Advection (not implemented)
+boundaryValue = 1
+timeStabilityFactor = 0.95  # Stable below 1 (explicit scheme)
+
+
+numThreads = 4

--- a/examples/diffusion/geometry.hpp
+++ b/examples/diffusion/geometry.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <lsBooleanOperation.hpp>
+#include <lsMakeGeometry.hpp>
+#include <lsWriteVisualizationMesh.hpp>
+
+#include <vcUtil.hpp>
+
+namespace geometry {
+
+using namespace viennals;
+
+template <class T, int D> using levelSetType = SmartPointer<Domain<T, D>>;
+template <class T, int D> using levelSetsType = std::vector<levelSetType<T, D>>;
+using materialMapType = SmartPointer<MaterialMap>;
+
+template <class T, int D>
+void addLevelSet(levelSetsType<T, D> &levelSets, levelSetType<T, D> levelSet,
+                 materialMapType matMap, int material,
+                 bool wrapLowerLevelSet = true) {
+  if (!levelSets.empty() && wrapLowerLevelSet) {
+    BooleanOperation<T, D>(levelSet, levelSets.back(),
+                           BooleanOperationEnum::UNION)
+        .apply();
+  }
+
+  levelSets.push_back(levelSet);
+  matMap->insertNextMaterial(material);
+}
+
+template <class T, int D>
+void makePlane(levelSetType<T, D> &domain, const T *origin, const T *normal) {
+  MakeGeometry<T, D>(domain, SmartPointer<Plane<T, D>>::New(origin, normal))
+      .apply();
+}
+
+template <class T, int D>
+void makeBox(levelSetType<T, D> &domain, const T *minPoint, const T *maxPoint) {
+  MakeGeometry<T, D>(domain, SmartPointer<Box<T, D>>::New(minPoint, maxPoint))
+      .apply();
+}
+
+template <class T, int D>
+auto makeStructure(util::Parameters &params, materialMapType matMap,
+                   int substrateMaterial, int maskMaterial) {
+  const T gridDelta = params.get("gridDelta");
+  const T substrateHeight = params.get("substrateHeight");
+  const T coverHeight = params.get("coverHeight");
+  const T maskHeight = params.get("maskHeight");
+  const T holeRadius = params.get("holeRadius");
+  BoundaryConditionEnum boundaryConds[D] = {
+      BoundaryConditionEnum::REFLECTIVE_BOUNDARY,
+      BoundaryConditionEnum::REFLECTIVE_BOUNDARY};
+  boundaryConds[D - 1] = BoundaryConditionEnum::INFINITE_BOUNDARY;
+  T bounds[2 * D] = {-params.get("xExtent") / 2., params.get("xExtent") / 2.,
+                     -params.get("yExtent") / 2., params.get("yExtent") / 2.};
+  bounds[2 * D - 2] = 0.;
+  bounds[2 * D - 1] = substrateHeight + maskHeight + gridDelta;
+
+  T origin[D] = {};
+  T normal[D] = {};
+  normal[D - 1] = 1.;
+
+  levelSetsType<T, D> levelSets;
+
+  // Substrate
+  origin[D - 1] = 0.;
+  auto bottom = levelSetType<T, D>::New(bounds, boundaryConds, gridDelta);
+  makePlane(bottom, origin, normal);
+  addLevelSet(levelSets, bottom, matMap, substrateMaterial);
+
+  origin[D - 1] = substrateHeight;
+  auto substrate = levelSetType<T, D>::New(bounds, boundaryConds, gridDelta);
+  makePlane(substrate, origin, normal);
+  addLevelSet(levelSets, substrate, matMap, substrateMaterial);
+
+  // Mask
+  if (maskHeight > 0.) {
+    auto mask = levelSetType<T, D>::New(bounds, boundaryConds, gridDelta);
+    origin[D - 1] = substrateHeight + maskHeight;
+    makePlane(mask, origin, normal);
+
+    auto maskAdd = levelSetType<T, D>::New(bounds, boundaryConds, gridDelta);
+
+    T minPoint[D] = {-holeRadius, -holeRadius};
+    T maxPoint[D] = {holeRadius, holeRadius};
+    minPoint[D - 1] = substrateHeight - gridDelta;
+    maxPoint[D - 1] = substrateHeight + maskHeight + gridDelta;
+
+    makeBox(maskAdd, minPoint, maxPoint);
+
+    BooleanOperation<T, D>(mask, maskAdd,
+                           BooleanOperationEnum::RELATIVE_COMPLEMENT)
+        .apply();
+
+    addLevelSet(levelSets, mask, matMap, maskMaterial);
+  }
+
+  return levelSets;
+}
+
+template <class T, int D>
+void saveVolumeMesh(std::string name, levelSetsType<T, D> &levelSets,
+                    materialMapType matMap) {
+  WriteVisualizationMesh<T, D> writer;
+  writer.setFileName(name);
+  for (const auto &ls : levelSets)
+    writer.insertNextLevelSet(ls);
+  writer.setMaterialMap(matMap);
+  writer.apply();
+}
+
+} // namespace geometry

--- a/examples/diffusionImplicit/CMakeLists.txt
+++ b/examples/diffusionImplicit/CMakeLists.txt
@@ -1,0 +1,7 @@
+project(diffusionImplicit LANGUAGES CXX)
+
+add_executable(${PROJECT_NAME} "${PROJECT_NAME}.cpp")
+target_link_libraries(${PROJECT_NAME} PRIVATE ViennaCS)
+configure_file(config.txt ${CMAKE_CURRENT_BINARY_DIR}/config.txt COPYONLY)
+
+add_dependencies(ViennaCS_Examples ${PROJECT_NAME})

--- a/examples/diffusionImplicit/config.txt
+++ b/examples/diffusionImplicit/config.txt
@@ -1,0 +1,20 @@
+# Domain
+gridDelta = 1.5  # nm
+xExtent = 80     # nm
+yExtent = 80     # nm
+
+# Geometry
+substrateHeight = 50  # nm
+coverHeight = 30
+maskHeight = 10
+holeRadius = 13.3
+
+# Process
+duration = 20               # s
+diffusionCoefficient = 1    # nm²/s
+velocity = 0                # Advection (not implemented)
+boundaryValue = 1
+timeStabilityFactor = 0.95  # Stable below 1 (explicit scheme)
+
+
+numThreads = 4

--- a/examples/diffusionImplicit/diffusionImplicit.cpp
+++ b/examples/diffusionImplicit/diffusionImplicit.cpp
@@ -1,0 +1,208 @@
+#include <csDenseCellSet.hpp>
+
+#include <eigen3/Eigen/SparseCholesky>
+#include <eigen3/Eigen/SparseCore>
+#include <eigen3/Eigen/SparseLU>
+
+#include "geometry.hpp"
+
+namespace cs = viennacs;
+namespace ls = viennals;
+
+using T = double;
+constexpr int D = 2;
+
+const int substrateMaterial = 0;
+const int maskMaterial = 1;
+const int coverMaterial = 2;
+
+struct SolutionData {
+  Eigen::SparseLU<Eigen::SparseMatrix<T>> solver;
+  std::unordered_map<int, int> cellMapping; // cellSet -> solution index
+  unsigned numCells = 0;
+  Eigen::SparseMatrix<T> systemMatrix;
+  Eigen::Matrix<T, Eigen::Dynamic, 1> rhs;
+};
+
+template <typename Material> bool isMaterial(Material x, int material) {
+  return static_cast<int>(x) == material;
+}
+
+template <typename Material>
+bool isDirichletBoundary(std::array<T, 3> center, Material material,
+                         cs::util::Parameters &params) {
+  return isMaterial(material, coverMaterial) &&
+         center[D - 1] <
+             params.get("substrateHeight") + params.get("gridDelta");
+}
+
+void addConcentration(cs::DenseCellSet<T, D> &cellSet,
+                      cs::util::Parameters &params) {
+  // Add quantity to be diffused (on top of the cell material)
+  auto concentration = cellSet.addScalarData("dopant", 0.);
+  auto materials = cellSet.getScalarData("Material");
+
+  const T boundaryValue = params.get("boundaryValue");
+
+  // Boundary condition: constant concentration at the top (outside)
+#pragma omp parallel for
+  for (int i = 0; i < cellSet.getNumberOfCells(); ++i) {
+    if (isDirichletBoundary(cellSet.getCellCenter(i), (*materials)[i],
+                            params)) {
+      (*concentration)[i] = boundaryValue;
+    }
+  }
+}
+
+// Implicit diffusion time-step (backward Euler)
+void solveDiffusionStep(SolutionData &sol, cs::DenseCellSet<T, D> &cellSet,
+                        cs::util::Parameters &params, T dt) {
+  auto data = cellSet.getScalarData("dopant");
+
+  sol.rhs = sol.solver.solve(sol.rhs);
+
+  if (sol.solver.info() != Eigen::Success) {
+    cs::Logger::getInstance().addError("Solving failed.").print();
+  }
+
+  // write results to cellSet
+  for (const auto &i : sol.cellMapping) {
+    (*data)[i.first] = sol.rhs[i.second];
+  }
+}
+
+void initCellMapping(SolutionData &sol, cs::DenseCellSet<T, D> &cellSet,
+                     cs::util::Parameters &params) {
+  auto materials = cellSet.getScalarData("Material");
+  sol.numCells = 0;
+  for (int i = 0; i < cellSet.getNumberOfCells(); ++i) {
+    if (isMaterial((*materials)[i], substrateMaterial) ||
+        isDirichletBoundary(cellSet.getCellCenter(i), (*materials)[i],
+                            params)) {
+      sol.cellMapping[i] = sol.numCells++;
+    }
+  }
+}
+
+void assembleMatrix(SolutionData &sol, cs::DenseCellSet<T, D> &cellSet,
+                    cs::util::Parameters &params, T dt) {
+  auto materials = cellSet.getScalarData("Material");
+  int material = substrateMaterial;
+  const T dx = cellSet.getGridDelta();
+  const T dtdx2 = dt / (dx * dx);
+
+  std::vector<Eigen::Triplet<T>> triplets; // (i,j,value) matrix entries
+  triplets.reserve(2 * D * sol.numCells);
+
+  for (const auto &ids : sol.cellMapping) {
+    auto i = ids.first;
+    auto cellMapIdx = ids.second;
+    bool onBoundary =
+        isDirichletBoundary(cellSet.getCellCenter(i), (*materials)[i], params);
+
+    // Boundary conditions
+    if (onBoundary) {
+      triplets.push_back({cellMapIdx, cellMapIdx, 1.}); // diagonal
+      continue;
+    }
+
+    const auto &neighbors = cellSet.getNeighbors(i);
+    T D_sum = 0;
+    for (auto n : neighbors) {
+      if (n >= 0 && !isMaterial((*materials)[n], maskMaterial)) {
+        T D_loc = params.get("diffusionCoefficient");
+        D_sum += D_loc;
+        triplets.emplace_back(cellMapIdx, sol.cellMapping[n], -dtdx2 * D_loc);
+      }
+    }
+
+    triplets.emplace_back(cellMapIdx, cellMapIdx, 1. + dtdx2 * D_sum);
+  }
+
+  sol.systemMatrix.resize(sol.numCells, sol.numCells);
+  sol.systemMatrix.setFromTriplets(triplets.begin(), triplets.end());
+  sol.systemMatrix.makeCompressed();
+}
+
+void assembleRHS(SolutionData &sol, cs::DenseCellSet<T, D> &cellSet,
+                 cs::util::Parameters &params) {
+  auto concentration = cellSet.getScalarData("dopant");
+  sol.rhs.resize(sol.numCells);
+
+  // Add boundary conditions
+  for (const auto &ids : sol.cellMapping) {
+    sol.rhs[ids.second] = (*concentration)[ids.first];
+  }
+}
+
+int main(int argc, char **argv) {
+  cs::Logger::setLogLevel(cs::LogLevel::INTERMEDIATE);
+
+  cs::util::Parameters params;
+  if (argc > 1) {
+    params.readConfigFile(argv[1]);
+  } else {
+    std::cout << "Usage: " << argv[0] << " <config file>" << std::endl;
+    return 1;
+  }
+  omp_set_num_threads(params.get<int>("numThreads"));
+
+  SolutionData solution;
+
+  auto matMap = cs::SmartPointer<ls::MaterialMap>::New();
+  auto levelSets = geometry::makeStructure<T, D>(
+      params, matMap, substrateMaterial, maskMaterial);
+
+  cs::DenseCellSet<T, D> cellSet;
+  T depth = params.get("substrateHeight") + params.get("coverHeight") + 10.;
+  cellSet.setCellSetPosition(true); // isAboveSurface
+  cellSet.setCoverMaterial(coverMaterial);
+  cellSet.fromLevelSets(levelSets, matMap, depth);
+
+  // We need neighborhood information for solving the diffusion equation
+  cellSet.buildNeighborhood();
+
+  addConcentration(cellSet, params);
+  cellSet.writeVTU("initial.vtu");
+
+  initCellMapping(solution, cellSet, params);
+  assembleRHS(solution, cellSet, params);
+
+  if (params.get("velocity") != 0.) {
+    const T stability =
+        2 * params.get("diffusionCoefficient") / params.get("velocity");
+    std::cout << "Stability: " << stability << std::endl;
+    if (0.5 * stability <= params.get("gridDelta"))
+      std::cout << "Unstable parameters. Reduce grid spacing!" << std::endl;
+  }
+
+  T duration = params.get("duration");
+  T dx = params.get("gridDelta");
+  T dt = std::min(dx * dx / (params.get("diffusionCoefficient") * 2 * D) *
+                      params.get("timeStabilityFactor"),
+                  duration);
+
+  assembleMatrix(solution, cellSet, params, dt);
+  solution.solver.compute(solution.systemMatrix);
+
+  if (solution.solver.info() != Eigen::Success) {
+    cs::Logger::getInstance().addError("Decomposition failed.").print();
+  }
+
+  T time = 0.;
+  while (time < duration) {
+
+    if (time + dt > duration) {
+      dt = duration - time;
+      assembleMatrix(solution, cellSet, params, dt);
+      solution.solver.compute(solution.systemMatrix);
+    }
+
+    solveDiffusionStep(solution, cellSet, params, dt);
+
+    time += dt;
+  }
+
+  // saveVolumeMesh("final", levelSets, matMap);
+  cellSet.writeVTU("final.vtu");
+}

--- a/examples/diffusionImplicit/geometry.hpp
+++ b/examples/diffusionImplicit/geometry.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <lsBooleanOperation.hpp>
+#include <lsMakeGeometry.hpp>
+#include <lsWriteVisualizationMesh.hpp>
+
+#include <vcUtil.hpp>
+
+namespace geometry {
+
+using namespace viennals;
+
+template <class T, int D> using levelSetType = SmartPointer<Domain<T, D>>;
+template <class T, int D> using levelSetsType = std::vector<levelSetType<T, D>>;
+using materialMapType = SmartPointer<MaterialMap>;
+
+template <class T, int D>
+void addLevelSet(levelSetsType<T, D> &levelSets, levelSetType<T, D> levelSet,
+                 materialMapType matMap, int material,
+                 bool wrapLowerLevelSet = true) {
+  if (!levelSets.empty() && wrapLowerLevelSet) {
+    BooleanOperation<T, D>(levelSet, levelSets.back(),
+                           BooleanOperationEnum::UNION)
+        .apply();
+  }
+
+  levelSets.push_back(levelSet);
+  matMap->insertNextMaterial(material);
+}
+
+template <class T, int D>
+void makePlane(levelSetType<T, D> &domain, const T *origin, const T *normal) {
+  MakeGeometry<T, D>(domain, SmartPointer<Plane<T, D>>::New(origin, normal))
+      .apply();
+}
+
+template <class T, int D>
+void makeBox(levelSetType<T, D> &domain, const T *minPoint, const T *maxPoint) {
+  MakeGeometry<T, D>(domain, SmartPointer<Box<T, D>>::New(minPoint, maxPoint))
+      .apply();
+}
+
+template <class T, int D>
+auto makeStructure(util::Parameters &params, materialMapType matMap,
+                   int substrateMaterial, int maskMaterial) {
+  const T gridDelta = params.get("gridDelta");
+  const T substrateHeight = params.get("substrateHeight");
+  const T coverHeight = params.get("coverHeight");
+  const T maskHeight = params.get("maskHeight");
+  const T holeRadius = params.get("holeRadius");
+  BoundaryConditionEnum boundaryConds[D] = {
+      BoundaryConditionEnum::REFLECTIVE_BOUNDARY,
+      BoundaryConditionEnum::REFLECTIVE_BOUNDARY};
+  boundaryConds[D - 1] = BoundaryConditionEnum::INFINITE_BOUNDARY;
+  T bounds[2 * D] = {-params.get("xExtent") / 2., params.get("xExtent") / 2.,
+                     -params.get("yExtent") / 2., params.get("yExtent") / 2.};
+  bounds[2 * D - 2] = 0.;
+  bounds[2 * D - 1] = substrateHeight + maskHeight + gridDelta;
+
+  T origin[D] = {};
+  T normal[D] = {};
+  normal[D - 1] = 1.;
+
+  levelSetsType<T, D> levelSets;
+
+  // Substrate
+  origin[D - 1] = 0.;
+  auto bottom = levelSetType<T, D>::New(bounds, boundaryConds, gridDelta);
+  makePlane(bottom, origin, normal);
+  addLevelSet(levelSets, bottom, matMap, substrateMaterial);
+
+  origin[D - 1] = substrateHeight;
+  auto substrate = levelSetType<T, D>::New(bounds, boundaryConds, gridDelta);
+  makePlane(substrate, origin, normal);
+  addLevelSet(levelSets, substrate, matMap, substrateMaterial);
+
+  // Mask
+  if (maskHeight > 0.) {
+    auto mask = levelSetType<T, D>::New(bounds, boundaryConds, gridDelta);
+    origin[D - 1] = substrateHeight + maskHeight;
+    makePlane(mask, origin, normal);
+
+    auto maskAdd = levelSetType<T, D>::New(bounds, boundaryConds, gridDelta);
+
+    T minPoint[D] = {-holeRadius, -holeRadius};
+    T maxPoint[D] = {holeRadius, holeRadius};
+    minPoint[D - 1] = substrateHeight - gridDelta;
+    maxPoint[D - 1] = substrateHeight + maskHeight + gridDelta;
+
+    makeBox(maskAdd, minPoint, maxPoint);
+
+    BooleanOperation<T, D>(mask, maskAdd,
+                           BooleanOperationEnum::RELATIVE_COMPLEMENT)
+        .apply();
+
+    addLevelSet(levelSets, mask, matMap, maskMaterial);
+  }
+
+  return levelSets;
+}
+
+template <class T, int D>
+void saveVolumeMesh(std::string name, levelSetsType<T, D> &levelSets,
+                    materialMapType matMap) {
+  WriteVisualizationMesh<T, D> writer;
+  writer.setFileName(name);
+  for (const auto &ls : levelSets)
+    writer.insertNextLevelSet(ls);
+  writer.setMaterialMap(matMap);
+  writer.apply();
+}
+
+} // namespace geometry


### PR DESCRIPTION
This adds the diffusion example with an implicit finite-difference scheme. It also improves the explicit diffusion example.

Since it requires the Eigen library to exist on the system, could this example be disabled by default when building all examples, or is it okay to leave it enabled?