### PR TITLE
Correctly link Eigen

### DIFF
--- a/examples/diffusionImplicit/CMakeLists.txt
+++ b/examples/diffusionImplicit/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package (Eigen3 3.3 NO_MODULE)
+find_package(Eigen3 3.3.2 NO_MODULE)
 
 if(NOT TARGET Eigen3::Eigen)
   message(STATUS "[ViennaCS] Eigen library not found, skipping example")
@@ -9,7 +9,7 @@ endif()
 project(diffusionImplicit LANGUAGES CXX)
 
 add_executable(${PROJECT_NAME} "${PROJECT_NAME}.cpp")
-target_link_libraries(${PROJECT_NAME} PRIVATE ViennaCS)
+target_link_libraries(${PROJECT_NAME} PRIVATE ViennaCS Eigen3::Eigen)
 configure_file(config.txt ${CMAKE_CURRENT_BINARY_DIR}/config.txt COPYONLY)
 
 add_dependencies(ViennaCS_Examples ${PROJECT_NAME})

--- a/examples/diffusionImplicit/diffusionImplicit.cpp
+++ b/examples/diffusionImplicit/diffusionImplicit.cpp
@@ -1,8 +1,14 @@
+/**
+  This example requires the Eigen library to be available, either by installing
+  it on the system or by passing a custom install location to the build system
+  (VIENNACS_LOOKUP_DIRS)
+*/
+
 #include <csDenseCellSet.hpp>
 
-#include <eigen3/Eigen/SparseCholesky>
-#include <eigen3/Eigen/SparseCore>
-#include <eigen3/Eigen/SparseLU>
+#include <Eigen/SparseCholesky>
+#include <Eigen/SparseCore>
+#include <Eigen/SparseLU>
 
 #include "geometry.hpp"
 


### PR DESCRIPTION
I realized that Eigen expects the pattern `#include <Eigen/Core>` when linking it with CMake, which adds `.../include/eigen3` to the search paths. When using `#include <eigen3/Eigen/Core>` it always uses the system version instead, ignoring CMake's found package.
I added the missing `target_link_libraries()` call, so now it should work with `find_package()`.

I also found that `VIENNACS_LOOKUP_DIRS` can be used to pass a custom install location, which I used to test version 3.3.2.